### PR TITLE
Add margins to Reading View tables

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -418,9 +418,6 @@ body {
 .el-table {
 	margin: var(--p-spacing) 0;
 }
-.markdown-rendered table {
-	margin: 0;
-}
 
 /* Embedded search results */
 .internal-query {


### PR DESCRIPTION
Maybe just is personal preference but change between **Reading View** and **Live Preview** feels weird with tables.

**Without margins:**

The table needs "jump" more than should and having content on top and bottom make that all "jump" along with the table.

https://github.com/user-attachments/assets/2ef3942a-7989-4c1a-96d9-ed669cd56047

**With margins:**

The table "jump" less and keep consistency with **Live Preview** (at least a bit).

https://github.com/user-attachments/assets/5be90f42-72db-42f9-8020-7ab370212a47

---

The change is hard to notice but can is annoying if you have long content with a table in the center.