### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Iridium",
 	"version": "1.8.15",
-	"minAppVersion": "1.12.4",
+	"minAppVersion": "1.13.0",
 	"author": "kyffa",
 	"authorUrl": "https://github.com/kyffa"
 }

--- a/theme.css
+++ b/theme.css
@@ -1303,15 +1303,15 @@ body:not(.i-callout-outlined, .i-callout-filled, .i-callout-outlined-filled) {
 	--callout-content-padding: 1em;
 
 	.callout-title {
-		background-color: rgb(var(--callout-color), 0.1);
+		background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
 	}
 
 	&.theme-light .callout-content {
-		border-top: var(--callout-border-width) dashed oklch(from rgb(var(--callout-color)) 0.65 c h / 0.45);
+		border-top: var(--callout-border-width) dashed oklch(from var(--callout-color) 0.65 c h / 0.45);
 	}
 
 	&.theme-dark .callout-content {
-		border-top: var(--callout-border-width) dashed oklch(from rgb(var(--callout-color)) 0.7 c h / 0.35);
+		border-top: var(--callout-border-width) dashed oklch(from var(--callout-color) 0.7 c h / 0.35);
 	}
 }
 
@@ -1325,11 +1325,11 @@ body:not(.i-callout-filled, .i-callout-outlined-filled) {
 	}
 
 	&.theme-light .callout {
-		border-color: oklch(from rgb(var(--callout-color)) 0.65 c h / 0.45);
+		border-color: oklch(from var(--callout-color) 0.65 c h / 0.45);
 	}
 
 	&.theme-dark .callout {
-		border-color: oklch(from rgb(var(--callout-color)) 0.7 c h / 0.35);
+		border-color: oklch(from var(--callout-color) 0.7 c h / 0.35);
 	}
 }
 
@@ -1341,13 +1341,13 @@ body:not(.i-callout-filled, .i-callout-outlined-filled) {
 
 .i-callout-outlined-filled {
 	&.theme-light .callout {
-		background-color: oklch(from rgb(var(--callout-color)) 0.65 c h / 0.06);
-		border-color: oklch(from rgb(var(--callout-color)) 0.65 c h / 0.3);
+		background-color: oklch(from var(--callout-color) 0.65 c h / 0.06);
+		border-color: oklch(from var(--callout-color) 0.65 c h / 0.3);
 	}
 
 	&.theme-dark .callout {
-		background-color: oklch(from rgb(var(--callout-color)) 0.75 c h / 0.08);
-		border-color: oklch(from rgb(var(--callout-color)) 0.75 c h / 0.2);
+		background-color: oklch(from var(--callout-color) 0.75 c h / 0.08);
+		border-color: oklch(from var(--callout-color) 0.75 c h / 0.2);
 	}
 }
 


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
